### PR TITLE
feat: works with git plugin's commit window

### DIFF
--- a/plugin/git_commit_prefix.vim
+++ b/plugin/git_commit_prefix.vim
@@ -11,5 +11,5 @@ let g:loaded_git_commit_prefix = 1
 
 augroup git_commit_prefix_settings
   autocmd!
-  autocmd VimEnter COMMIT_EDITMSG startinsert | call feedkeys("\<C-R>=git_commit_prefix#candidates()\<CR>")
+  autocmd FileType g*commit startinsert | call feedkeys("\<C-R>=git_commit_prefix#candidates()\<CR>")
 augroup END


### PR DESCRIPTION
Changes the plugin execution timing to when `FileType` event fired.